### PR TITLE
fix: extract paths, SYSTEM_VER, recursive scan, grid crashes

### DIFF
--- a/PS4PKGTool.Tests/OrbisTempSafetyTests.cs
+++ b/PS4PKGTool.Tests/OrbisTempSafetyTests.cs
@@ -1,0 +1,208 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PS4PKGTool.Utilities.PS4PKGToolHelper;
+
+namespace PS4PKGTool.Tests;
+
+[TestClass]
+public class OrbisTempSafetyTests
+{
+    private string _dir = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "p4t_test_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, true);
+        }
+        catch { /* best effort */ }
+    }
+
+    [TestMethod]
+    public void BeginRename_WritesSidecar_AndMovesFile()
+    {
+        string orig = Path.Combine(_dir, "Game Title.pkg");
+        string temp = Path.Combine(_dir, OrbisTempSafety.TempPkgPrefix + "abc123.pkg");
+        File.WriteAllBytes(orig, new byte[] { 10, 20, 30 });
+
+        OrbisTempSafety.BeginOrbisPkgRename(orig, temp);
+
+        Assert.IsFalse(File.Exists(orig), "original should be moved away");
+        Assert.IsTrue(File.Exists(temp), "temp PKG should exist");
+        string side = OrbisTempSafety.SidecarPath(temp);
+        Assert.IsTrue(File.Exists(side), "restore sidecar should exist");
+        Assert.AreEqual(orig, File.ReadAllText(side).Trim());
+    }
+
+    [TestMethod]
+    public void EndRestore_MovesBack_AndRemovesSidecar()
+    {
+        string orig = Path.Combine(_dir, "Restore Me.pkg");
+        string temp = Path.Combine(_dir, OrbisTempSafety.TempPkgPrefix + "def456.pkg");
+        File.WriteAllBytes(orig, new byte[] { 1, 2, 3, 4 });
+        OrbisTempSafety.BeginOrbisPkgRename(orig, temp);
+
+        OrbisTempSafety.EndOrbisPkgRestore(temp, orig);
+
+        Assert.IsTrue(File.Exists(orig));
+        Assert.IsFalse(File.Exists(temp));
+        Assert.IsFalse(File.Exists(OrbisTempSafety.SidecarPath(temp)));
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, File.ReadAllBytes(orig));
+    }
+
+    [TestMethod]
+    public void RecoverOrphans_RestoresUsingSidecar()
+    {
+        string orig = Path.Combine(_dir, "Crashed Game.pkg");
+        string temp = Path.Combine(_dir, OrbisTempSafety.TempPkgPrefix + Guid.NewGuid().ToString("N") + ".pkg");
+        File.WriteAllBytes(orig, new byte[] { 9, 9, 9 });
+        OrbisTempSafety.BeginOrbisPkgRename(orig, temp);
+
+        // Simulate crash: leave temp + sidecar, do not call EndRestore
+        Assert.IsFalse(File.Exists(orig));
+        Assert.IsTrue(File.Exists(temp));
+
+        int n = OrbisTempSafety.RecoverOrphanedPkgs(new[] { _dir });
+        Assert.IsTrue(n >= 1, "should restore at least one orphan");
+        Assert.IsTrue(File.Exists(orig), "original path restored");
+        Assert.IsFalse(File.Exists(temp), "temp name gone");
+        Assert.IsFalse(File.Exists(OrbisTempSafety.SidecarPath(temp)));
+    }
+
+    [TestMethod]
+    public void RecoverOrphans_WhenOriginalExists_LeavesTemp()
+    {
+        string orig = Path.Combine(_dir, "Already There.pkg");
+        string temp = Path.Combine(_dir, OrbisTempSafety.TempPkgPrefix + "conflict.pkg");
+        File.WriteAllBytes(orig, new byte[] { 1 });
+        File.WriteAllBytes(temp, new byte[] { 2, 2 });
+        File.WriteAllText(OrbisTempSafety.SidecarPath(temp), orig);
+
+        int n = OrbisTempSafety.RecoverOrphanedPkgs(new[] { _dir });
+        // Should not overwrite existing original
+        Assert.IsTrue(File.Exists(orig));
+        Assert.IsTrue(File.Exists(temp), "temp should remain when original exists");
+        CollectionAssert.AreEqual(new byte[] { 1 }, File.ReadAllBytes(orig));
+        Assert.IsTrue(n == 0 || File.Exists(temp)); // recovery count 0 for this case
+    }
+
+    [TestMethod]
+    public void RecoverOrphans_FindsTempInsideP4tSubfolder()
+    {
+        string sub = Path.Combine(_dir, "p4t_v_abc123");
+        Directory.CreateDirectory(sub);
+        string orig = Path.Combine(_dir, "Nested.pkg");
+        string temp = Path.Combine(sub, OrbisTempSafety.TempPkgPrefix + "nested.pkg");
+        File.WriteAllBytes(orig, new byte[] { 7, 7 });
+        OrbisTempSafety.BeginOrbisPkgRename(orig, temp);
+
+        int n = OrbisTempSafety.RecoverOrphanedPkgs(new[] { _dir });
+        Assert.IsTrue(n >= 1);
+        Assert.IsTrue(File.Exists(orig));
+        Assert.IsFalse(File.Exists(temp));
+    }
+
+    [TestMethod]
+    public void CleanupStaleTempDirectories_RemovesOldP4tFolders()
+    {
+        // Use system temp so CleanupStaleTempDirectories scans it
+        string stale = Path.Combine(Path.GetTempPath(), "p4t_z_" + Guid.NewGuid().ToString("N").Substring(0, 6));
+        Directory.CreateDirectory(stale);
+        File.WriteAllText(Path.Combine(stale, "junk.txt"), "x");
+        Directory.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddHours(-12));
+        Directory.SetCreationTimeUtc(stale, DateTime.UtcNow.AddHours(-12));
+
+        string fresh = Path.Combine(Path.GetTempPath(), "p4t_z_" + Guid.NewGuid().ToString("N").Substring(0, 6));
+        Directory.CreateDirectory(fresh);
+        File.WriteAllText(Path.Combine(fresh, "new.txt"), "y");
+
+        try
+        {
+            int cleaned = OrbisTempSafety.CleanupStaleTempDirectories(TimeSpan.FromHours(6));
+            Assert.IsTrue(cleaned >= 1, "expected at least one stale folder removed");
+            Assert.IsFalse(Directory.Exists(stale), "stale p4t folder should be deleted");
+            Assert.IsTrue(Directory.Exists(fresh), "fresh p4t folder should remain");
+        }
+        finally
+        {
+            try { if (Directory.Exists(fresh)) Directory.Delete(fresh, true); } catch { }
+            try { if (Directory.Exists(stale)) Directory.Delete(stale, true); } catch { }
+        }
+    }
+
+    [TestMethod]
+    public void CleanupStaleTempDirectories_SkipsFolderWithActiveSidecar()
+    {
+        string active = Path.Combine(Path.GetTempPath(), "p4t_a_" + Guid.NewGuid().ToString("N").Substring(0, 6));
+        Directory.CreateDirectory(active);
+        string tempPkg = Path.Combine(active, OrbisTempSafety.TempPkgPrefix + "live.pkg");
+        File.WriteAllBytes(tempPkg, new byte[] { 3 });
+        File.WriteAllText(OrbisTempSafety.SidecarPath(tempPkg), Path.Combine(_dir, "live-orig.pkg"));
+        Directory.SetLastWriteTimeUtc(active, DateTime.UtcNow.AddHours(-12));
+        Directory.SetCreationTimeUtc(active, DateTime.UtcNow.AddHours(-12));
+
+        try
+        {
+            OrbisTempSafety.CleanupStaleTempDirectories(TimeSpan.FromHours(6));
+            Assert.IsTrue(Directory.Exists(active), "folder with active sidecar must not be deleted");
+            Assert.IsTrue(File.Exists(tempPkg));
+        }
+        finally
+        {
+            try { Directory.Delete(active, true); } catch { }
+        }
+    }
+
+    [TestMethod]
+    public void HasEnoughDiskSpace_TinyPkg_Succeeds()
+    {
+        string pkg = Path.Combine(_dir, "tiny.pkg");
+        File.WriteAllBytes(pkg, new byte[4096]);
+        bool ok = OrbisTempSafety.HasEnoughDiskSpaceForExtract(pkg, _dir, out string? msg);
+        Assert.IsTrue(ok, msg ?? "expected enough space for 4KB pkg");
+        Assert.IsTrue(string.IsNullOrEmpty(msg));
+    }
+
+    [TestMethod]
+    public void HasEnoughDiskSpace_ZeroLengthPkg_Fails()
+    {
+        string pkg = Path.Combine(_dir, "empty.pkg");
+        File.WriteAllBytes(pkg, Array.Empty<byte>());
+        bool ok = OrbisTempSafety.HasEnoughDiskSpaceForExtract(pkg, _dir, out string? msg);
+        Assert.IsFalse(ok);
+        Assert.IsFalse(string.IsNullOrEmpty(msg));
+    }
+
+    [TestMethod]
+    public void SafeMoveFile_SameVolume_Works()
+    {
+        string a = Path.Combine(_dir, "a.bin");
+        string b = Path.Combine(_dir, "b.bin");
+        File.WriteAllBytes(a, new byte[] { 5, 5, 5 });
+        OrbisTempSafety.SafeMoveFile(a, b);
+        Assert.IsFalse(File.Exists(a));
+        Assert.IsTrue(File.Exists(b));
+        CollectionAssert.AreEqual(new byte[] { 5, 5, 5 }, File.ReadAllBytes(b));
+    }
+
+    [TestMethod]
+    public void EndRestore_Idempotent_WhenAlreadyRestored()
+    {
+        string orig = Path.Combine(_dir, "Idem.pkg");
+        string temp = Path.Combine(_dir, OrbisTempSafety.TempPkgPrefix + "idem.pkg");
+        File.WriteAllBytes(orig, new byte[] { 8 });
+        OrbisTempSafety.BeginOrbisPkgRename(orig, temp);
+        OrbisTempSafety.EndOrbisPkgRestore(temp, orig);
+        // Second call must not throw
+        OrbisTempSafety.EndOrbisPkgRestore(temp, orig);
+        Assert.IsTrue(File.Exists(orig));
+    }
+}

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -297,6 +297,26 @@ namespace PS4PKGTool
         private static void SafeMoveFile(string src, string dst) => OrbisTempSafety.SafeMoveFile(src, dst);
 
         /// <summary>
+        /// After cancel/fail, remove the title extract folder if it has no files
+        /// (avoids leaving an empty "Game Title" directory).
+        /// </summary>
+        private static void TryRemoveEmptyExtractFolder(string dir)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir)) return;
+                if (Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories).Any())
+                    return; // partial extract — leave it
+                Directory.Delete(dir, recursive: true);
+                Logger.LogInformation("Removed empty extract folder after cancel/fail: " + dir);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Could not remove empty extract folder: " + ex.Message);
+            }
+        }
+
+        /// <summary>
         /// Wait for orbis-pub-cmd without a hard 10-minute kill (issue #76).
         /// Polls every second for cancel; optional progress callback for UI status.
         /// </summary>
@@ -5238,6 +5258,7 @@ namespace PS4PKGTool
                             if (userCancelled)
                             {
                                 e.Cancel = true; // RunWorkerCompleted → "Extraction cancelled."
+                                TryRemoveEmptyExtractFolder(extractLocation);
                             }
                             else if (exitCode != 0)
                             {
@@ -5245,12 +5266,14 @@ namespace PS4PKGTool
                                 if (_extractionStopRequested || _extractWorker.CancellationPending)
                                 {
                                     e.Cancel = true;
+                                    TryRemoveEmptyExtractFolder(extractLocation);
                                 }
                                 else
                                 {
                                     string errMsg = FormatOrbisError(extractOutput);
                                     Logger.LogError($"orbis-pub-cmd exit code: {exitCode}, cancelPending={_extractWorker.CancellationPending}\n{errMsg}");
                                     this.Invoke(() => ShowError($"orbis-pub-cmd error:\n{errMsg}", true));
+                                    TryRemoveEmptyExtractFolder(extractLocation);
                                 }
                             }
                             else
@@ -5275,7 +5298,12 @@ namespace PS4PKGTool
                                             SafeMoveFile(entry, dest);
                                     }
                                 }
-                                if (!e.Cancel)
+                                if (e.Cancel)
+                                {
+                                    // Stopped while moving — drop the title folder only if nothing useful was written
+                                    TryRemoveEmptyExtractFolder(extractLocation);
+                                }
+                                else
                                 {
                                     Logger.LogInformation($"PKG extracted to \"{extractLocation}\".");
                                     this.Invoke(() => ShowInformation($"PKG extracted.", false));

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -1,4 +1,4 @@
-﻿using ByteSizeLib;
+using ByteSizeLib;
 using ClosedXML.Excel;
 using DarkUI.Config;
 using DarkUI.Controls;
@@ -4716,20 +4716,22 @@ namespace PS4PKGTool
         /// Returns a writable directory on the same drive for the orbis temp rename.
         /// If the PKG's own directory is already ASCII, it's used (in-place rename).
         /// Otherwise walks up to the nearest ASCII-named ancestor and creates a
-        /// short temp dir there — the drive root is NOT used (not writable without
-        /// admin on C:).
+        /// short temp dir there. Prefers same-volume ASCII roots so multi-GB PKGs can
+        /// File.Move without a cross-drive copy. Never hands orbis a non-ASCII path.
         /// </summary>
         private static string GetOrbisTempDirFor(string pkgPath)
         {
             string dir = Path.GetDirectoryName(pkgPath);
-            if (!string.IsNullOrEmpty(dir) && dir.All(c => c < 128))
+            if (!string.IsNullOrEmpty(dir) && dir.IsAsciiPath())
                 return dir;
 
-            while (!string.IsNullOrEmpty(dir) && !dir.All(c => c < 128))
+            while (!string.IsNullOrEmpty(dir) && !dir.IsAsciiPath())
                 dir = Path.GetDirectoryName(dir);
 
-            if (string.IsNullOrEmpty(dir))
-                dir = Path.GetTempPath(); // fallback — rare, all-ancestors-Unicode
+            // No ASCII ancestor (e.g. D:\ゲーム\title.pkg) — pick a writable ASCII root,
+            // preferring the PKG's volume when possible.
+            if (string.IsNullOrEmpty(dir) || !dir.IsAsciiPath())
+                dir = GetAsciiTempRoot(pkgPath);
 
             string temp = Path.Combine(dir, "p4t_v_" + Guid.NewGuid().ToString("N").Substring(0, 6));
             Directory.CreateDirectory(temp);
@@ -5453,7 +5455,9 @@ namespace PS4PKGTool
 
         /// <summary>
         /// Synchronous version of ExtractSelectedPKGData for drag-drop.
-        /// orbis-pub-cmd needs the target directory to exist, so we pre-create it.
+        /// Always routes orbis-pub-cmd through ASCII-safe temp paths: non-ASCII titles
+        /// (e.g. fullwidth ＆, Japanese) cause "in_path or out_path is invalid" if passed
+        /// directly. Extracted files are then moved to the real destination.
         /// </summary>
         private void ExtractFilesSync(List<string> nodeList, string extractLocation, bool preserveStructure)
         {
@@ -5475,11 +5479,19 @@ namespace PS4PKGTool
                         ? Path.Combine(extractLocation, targ_path.TrimEnd('/').Replace("/", @"\"))
                         : Path.Combine(extractLocation, Path.GetFileName(targ_path.TrimEnd('/')));
 
-                    // Pre-create output directory/file path
+                    // Pre-create final destination (may contain Unicode — fine for .NET / NTFS).
                     if (isDirectory)
                         Directory.CreateDirectory(out_path);
                     else
                         Directory.CreateDirectory(Path.GetDirectoryName(out_path) ?? extractLocation);
+
+                    // ASCII-only temp output for orbis-pub-cmd (mirrors ExtractSelectedPKGData).
+                    string tempBase = CreateOrbisTempDir("x");
+                    string tempOutPath = isDirectory
+                        ? tempBase
+                        : Path.Combine(tempBase, Path.GetFileName(out_path).ToOrbisSafeName());
+                    if (!isDirectory)
+                        Directory.CreateDirectory(Path.GetDirectoryName(tempOutPath) ?? tempBase);
 
                     string arcPath = isDirectory ? targ_path : targ_path.TrimEnd('/');
                     var extractStartInfo = new ProcessStartInfo
@@ -5493,7 +5505,7 @@ namespace PS4PKGTool
                     extractStartInfo.ArgumentList.Add("--passcode");
                     extractStartInfo.ArgumentList.Add(DefaultOrbisPasscode);
                     extractStartInfo.ArgumentList.Add(safeIn + ":" + arcPath);
-                    extractStartInfo.ArgumentList.Add(out_path);
+                    extractStartInfo.ArgumentList.Add(tempOutPath);
                     using var proc = new Process { StartInfo = extractStartInfo };
                     proc.Start();
                     Task<string> procReadTask = proc.StandardOutput.ReadToEndAsync();
@@ -5501,7 +5513,42 @@ namespace PS4PKGTool
                     {
                         try { proc.Kill(); proc.WaitForExit(); } catch { }
                     }
-                    _ = procReadTask.Result; // drain so a stalled process cannot deadlock the pipe
+                    string extractOutput = procReadTask.Result;
+                    int exitCode = proc.ExitCode;
+
+                    if (exitCode == 0)
+                    {
+                        if (isDirectory)
+                        {
+                            if (Directory.Exists(tempOutPath))
+                            {
+                                foreach (string entry in Directory.GetFileSystemEntries(tempOutPath))
+                                {
+                                    string dest = Path.Combine(out_path, Path.GetFileName(entry));
+                                    try { if (Directory.Exists(dest)) Directory.Delete(dest, true); } catch (Exception ex) { Logger.LogWarning("Failed to delete dest dir: " + ex.Message); }
+                                    if (Directory.Exists(entry))
+                                        SafeMoveDirectory(entry, dest);
+                                    else
+                                    {
+                                        try { if (File.Exists(dest)) File.Delete(dest); } catch (Exception ex) { Logger.LogWarning("Failed to delete dest file: " + ex.Message); }
+                                        File.Move(entry, dest);
+                                    }
+                                }
+                            }
+                        }
+                        else if (File.Exists(tempOutPath))
+                        {
+                            try { if (File.Exists(out_path)) File.Delete(out_path); } catch (Exception ex) { Logger.LogWarning("Failed to delete output file: " + ex.Message); }
+                            File.Move(tempOutPath, out_path);
+                        }
+                    }
+                    else
+                    {
+                        string errMsg = FormatOrbisError(extractOutput);
+                        Logger.LogError($"orbis-pub-cmd failed (sync) for \"{targ_path}\": exit={exitCode}\n{errMsg}");
+                    }
+
+                    try { if (Directory.Exists(tempBase)) Directory.Delete(tempBase, true); } catch (Exception ex) { Logger.LogWarning("Failed to clean sync extract temp: " + ex.Message); }
                 }
             }
             finally

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -294,19 +294,7 @@ namespace PS4PKGTool
         }
 
         /// <summary>Move a file, falling back to copy+delete when volumes differ (e.g. D: PKG → C: temp).</summary>
-        private static void SafeMoveFile(string src, string dst)
-        {
-            try
-            {
-                if (File.Exists(dst)) File.Delete(dst);
-                File.Move(src, dst);
-            }
-            catch (IOException)
-            {
-                File.Copy(src, dst, overwrite: true);
-                try { File.Delete(src); } catch { /* leave source if delete fails after copy */ }
-            }
-        }
+        private static void SafeMoveFile(string src, string dst) => OrbisTempSafety.SafeMoveFile(src, dst);
 
         /// <summary>
         /// Wait for orbis-pub-cmd without a hard 10-minute kill (issue #76).
@@ -440,6 +428,24 @@ namespace PS4PKGTool
                 this.Text = "PS4 PKG Tool " + ApplicationVersion;
                 await Task.Run(() =>
             {
+                // Recover PKG renames left behind by a crash mid-extract/view, and prune old temps.
+                try
+                {
+                    var recoveryRoots = new List<string>();
+                    if (appSettings_?.PkgDirectories != null)
+                        recoveryRoots.AddRange(appSettings_.PkgDirectories);
+                    recoveryRoots.Add(GetAsciiTempRoot());
+                    recoveryRoots.Add(Path.GetTempPath());
+                    int restored = OrbisTempSafety.RecoverOrphanedPkgs(recoveryRoots);
+                    int cleaned = OrbisTempSafety.CleanupStaleTempDirectories(TimeSpan.FromHours(6));
+                    if (restored > 0 || cleaned > 0)
+                        Logger.LogInformation($"Startup reliability: restored {restored} orphan PKG(s), cleaned {cleaned} temp folder(s).");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning("Startup orphan/temp cleanup failed: " + ex.Message);
+                }
+
                 Logger.LogInformation("Selected directory: ");
 
                 foreach (var folder in appSettings_.PkgDirectories)
@@ -4824,7 +4830,7 @@ namespace PS4PKGTool
                 origPath = PKG.SelectedPKGFilename;
                 string dir = GetOrbisTempDirFor(origPath);
                 tempPath = Path.Combine(dir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
-                SafeMoveFile(origPath, tempPath);
+                OrbisTempSafety.BeginOrbisPkgRename(origPath, tempPath);
                 renamed = true;
                 string safePkgPath = tempPath;
 
@@ -4946,19 +4952,19 @@ namespace PS4PKGTool
                 }
                 finally
                 {
-                    if (renamed && File.Exists(tempPath) && !File.Exists(origPath))
+                    if (renamed)
                     {
-                        try { SafeMoveFile(tempPath, origPath); } catch { }
+                        try { OrbisTempSafety.EndOrbisPkgRestore(tempPath, origPath); } catch { }
                     }
                     DeleteOrbisTempDir(tempPath);
                 }
             };
             bg.RunWorkerCompleted += delegate (object sender, RunWorkerCompletedEventArgs e)
             {
-                // Restore original filename
-                if (renamed && File.Exists(tempPath) && !File.Exists(origPath))
+                // Restore original filename (in case finally did not run on abort)
+                if (renamed && File.Exists(tempPath))
                 {
-                    try { SafeMoveFile(tempPath, origPath); }
+                    try { OrbisTempSafety.EndOrbisPkgRestore(tempPath, origPath); }
                     catch (Exception ex) { Logger.LogError("Failed to restore PKG filename. Recover from " + tempPath + ": " + ex.Message); }
                 }
                 DeleteOrbisTempDir(tempPath);
@@ -5120,8 +5126,16 @@ namespace PS4PKGTool
                 _extractWorker = new BackgroundWorker { WorkerSupportsCancellation = true };
                 if (ShowFolderBrowserDialog(out FolderBrowserDialog fbd))
                 {
-                    Helper.IsOperationRunning = true;
                     string extractLocation = fbd.SelectedPath;
+                    string pkgForSpace = PKG.SelectedPKGFilename;
+                    if (!string.IsNullOrEmpty(pkgForSpace)
+                        && !OrbisTempSafety.HasEnoughDiskSpaceForExtract(pkgForSpace, extractLocation, out string spaceMsg))
+                    {
+                        ShowError(spaceMsg ?? "Not enough free disk space to extract.", true);
+                        return;
+                    }
+
+                    Helper.IsOperationRunning = true;
                     btnExtractFullPKG.Text = "Stop Extract";
                     SetExtractionUiEnabled(false); // lock the app — only the stop button stays usable
                     listView1?.Invalidate();       // force the DLV to repaint in its disabled (grey) state
@@ -5165,7 +5179,7 @@ namespace PS4PKGTool
                         string dir = GetOrbisTempDirFor(origPath);
                         string tempPath = Path.Combine(dir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
                         bool renamed = false;
-                        SafeMoveFile(origPath, tempPath);
+                        OrbisTempSafety.BeginOrbisPkgRename(origPath, tempPath);
                         renamed = true;
                         string pkgPath = tempPath;
 
@@ -5261,15 +5275,9 @@ namespace PS4PKGTool
                         }
                         finally
                         {
-                            if (renamed && File.Exists(tempPath))
+                            if (renamed)
                             {
-                                try
-                                {
-                                    if (File.Exists(origPath))
-                                        Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + tempPath);
-                                    else
-                                        SafeMoveFile(tempPath, origPath);
-                                }
+                                try { OrbisTempSafety.EndOrbisPkgRestore(tempPath, origPath); }
                                 catch (Exception ex)
                                 {
                                     Logger.LogError("Failed to restore PKG filename. Recover the PKG from " + tempPath + ": " + ex.Message);
@@ -5407,7 +5415,7 @@ namespace PS4PKGTool
                     string renameDir = GetOrbisTempDirFor(in_path);
                     string renameTmp = Path.Combine(renameDir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
                     bool wasRenamed = false;
-                    SafeMoveFile(in_path, renameTmp);
+                    OrbisTempSafety.BeginOrbisPkgRename(in_path, renameTmp);
                     wasRenamed = true;
                     string safeIn = renameTmp;
 
@@ -5487,15 +5495,9 @@ namespace PS4PKGTool
                     }
                     finally
                     {
-                        if (wasRenamed && File.Exists(renameTmp))
+                        if (wasRenamed)
                         {
-                            try
-                            {
-                                if (File.Exists(in_path))
-                                    Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + renameTmp);
-                                else
-                                    SafeMoveFile(renameTmp, in_path);
-                            }
+                            try { OrbisTempSafety.EndOrbisPkgRestore(renameTmp, in_path); }
                             catch (Exception rex)
                             {
                                 Logger.LogInformation($"CRITICAL: Failed to restore PKG! File at: {renameTmp}");
@@ -5553,7 +5555,7 @@ namespace PS4PKGTool
             string renameDir = GetOrbisTempDirFor(inPath);
             string renameTmp = Path.Combine(renameDir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
             bool wasRenamed = false;
-            SafeMoveFile(inPath, renameTmp);
+            OrbisTempSafety.BeginOrbisPkgRename(inPath, renameTmp);
             wasRenamed = true;
             string safeIn = renameTmp;
 
@@ -5639,15 +5641,9 @@ namespace PS4PKGTool
             }
             finally
             {
-                if (wasRenamed && File.Exists(renameTmp))
+                if (wasRenamed)
                 {
-                    try
-                    {
-                        if (File.Exists(inPath))
-                            Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + renameTmp);
-                        else
-                            SafeMoveFile(renameTmp, inPath);
-                    }
+                    try { OrbisTempSafety.EndOrbisPkgRestore(renameTmp, inPath); }
                     catch (Exception rex)
                     {
                         Logger.LogInformation($"CRITICAL: Failed to restore PKG! File at: {renameTmp}");
@@ -5891,7 +5887,7 @@ namespace PS4PKGTool
 
             try
             {
-                SafeMoveFile(origPath, renameTmp);
+                OrbisTempSafety.BeginOrbisPkgRename(origPath, renameTmp);
                 renamed = true;
                 tempDir = CreateOrbisTempDir("c"); // short ASCII temp root (see CreateOrbisTempDir)
                 string orbisPubCmdErrorMessage = "";
@@ -5958,15 +5954,9 @@ namespace PS4PKGTool
             }
             finally
             {
-                if (renamed && File.Exists(renameTmp))
+                if (renamed)
                 {
-                    try
-                    {
-                        if (File.Exists(origPath))
-                            Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + renameTmp);
-                        else
-                            SafeMoveFile(renameTmp, origPath);
-                    }
+                    try { OrbisTempSafety.EndOrbisPkgRestore(renameTmp, origPath); }
                     catch (Exception rex)
                     {
                         Logger.LogInformation($"CRITICAL: Failed to restore PKG! File at: {renameTmp}");

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -967,6 +967,13 @@ namespace PS4PKGTool
                     npCommunicationId = cachedId;
                     Logger.LogInformation("Using cached NP Communication ID for " + pkg.Content_ID + ": " + cachedId);
                 }
+                else
+                {
+                    // Resolve on demand so names work without a pre-built settings cache.
+                    npCommunicationId = await TryResolveNpCommunicationIdAsync(pkgPath, pkg.Content_ID, cache)
+                        .ConfigureAwait(true);
+                    if (loadVersion != _trophyLoadVersion) return;
+                }
 
                 TRPReader legacyReader = null;
                 TrophyMetadataResult result = await Task.Run(() =>
@@ -984,6 +991,56 @@ namespace PS4PKGTool
             catch (Exception ex)
             {
                 Logger.LogError("Error in LoadTrophyInfo", ex);
+            }
+        }
+
+        /// <summary>
+        /// Extracts Sc0/npbind.dat from the PKG when the Content ID is not in the trophy cache.
+        /// Stores a successful result so later selections skip extraction.
+        /// </summary>
+        private async Task<string> TryResolveNpCommunicationIdAsync(
+            string pkgPath,
+            string contentId,
+            NpCommunicationIdCache cache)
+        {
+            if (string.IsNullOrWhiteSpace(pkgPath) || !File.Exists(pkgPath))
+                return null;
+            if (!File.Exists(OrbisPubCmd))
+            {
+                Logger.LogWarning("Cannot resolve NP Communication ID: orbis-pub-cmd.exe was not found.");
+                return null;
+            }
+
+            try
+            {
+                Logger.LogInformation("Extracting NP Communication ID from PKG for " + contentId + "...");
+                string temporaryRoot = Path.Combine(AppDataDirectory, "TrophyMetadata", "Temp");
+                var extractor = new NpbindExtractor();
+                NpbindExtractionResult extraction = await extractor.ExtractAsync(
+                    OrbisPubCmd, pkgPath, temporaryRoot).ConfigureAwait(false);
+
+                if (!extraction.Succeeded || extraction.NpCommunicationId == null)
+                {
+                    Logger.LogWarning("NP Communication ID extraction failed for " + contentId + ": " + extraction.ErrorMessage);
+                    return null;
+                }
+
+                try
+                {
+                    cache.Set(contentId, extraction.NpCommunicationId);
+                    Logger.LogInformation("Cached NP Communication ID for " + contentId + ": " + extraction.NpCommunicationId);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning("NP Communication ID was resolved but could not be cached: " + ex.Message);
+                }
+
+                return extraction.NpCommunicationId;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("NP Communication ID extraction failed for " + contentId + ": " + ex.Message);
+                return null;
             }
         }
 

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -293,6 +293,44 @@ namespace PS4PKGTool
             }
         }
 
+        /// <summary>Move a file, falling back to copy+delete when volumes differ (e.g. D: PKG → C: temp).</summary>
+        private static void SafeMoveFile(string src, string dst)
+        {
+            try
+            {
+                if (File.Exists(dst)) File.Delete(dst);
+                File.Move(src, dst);
+            }
+            catch (IOException)
+            {
+                File.Copy(src, dst, overwrite: true);
+                try { File.Delete(src); } catch { /* leave source if delete fails after copy */ }
+            }
+        }
+
+        /// <summary>
+        /// Wait for orbis-pub-cmd without a hard 10-minute kill (issue #76).
+        /// Polls every second for cancel; optional progress callback for UI status.
+        /// </summary>
+        private bool WaitForOrbisProcess(Process extract, Func<bool> isCancelRequested, Action onProgressTick = null)
+        {
+            int ticks = 0;
+            while (!extract.WaitForExit(1000))
+            {
+                if (isCancelRequested())
+                {
+                    try { extract.Kill(entireProcessTree: true); } catch { try { extract.Kill(); } catch { } }
+                    try { extract.WaitForExit(15000); } catch { }
+                    return false; // cancelled / killed
+                }
+                ticks++;
+                // Throttle progress work (full tree size scan is expensive on large extracts)
+                if (onProgressTick != null && ticks % 3 == 0)
+                    onProgressTick();
+            }
+            return true; // exited on its own
+        }
+
         private string GroupByColumn =>
             cbGroupBy.SelectedItem?.ToString() ?? "Category";
 
@@ -2126,8 +2164,8 @@ namespace PS4PKGTool
                         {
                             if (t.Name == "SYSTEM_VER")
                             {
-                                if (int.TryParse(t.Value, out int value) && value != 0)
-                                    pkgMinFirmware = FormatPkgSystemVersion(value);
+                                if (uint.TryParse(t.Value, out uint value) && value != 0)
+                                    pkgMinFirmware = FormatPkgSystemVersion(unchecked((int)value));
                                 else pkgMinFirmware = t.Value;
                             }
                             if (t.Name == "VERSION") pkgVersion = verRegex2.Replace(t.Value, "");
@@ -2487,8 +2525,8 @@ namespace PS4PKGTool
                     {
                         if (t.Name == "SYSTEM_VER")
                         {
-                            if (int.TryParse(t.Value, out int value) && value != 0)
-                                pkgSystemVersion = FormatPkgSystemVersion(value);
+                            if (uint.TryParse(t.Value, out uint value) && value != 0)
+                                pkgSystemVersion = FormatPkgSystemVersion(unchecked((int)value));
                             else pkgSystemVersion = t.Value;
                         }
                         if (t.Name == "VERSION")
@@ -4786,7 +4824,7 @@ namespace PS4PKGTool
                 origPath = PKG.SelectedPKGFilename;
                 string dir = GetOrbisTempDirFor(origPath);
                 tempPath = Path.Combine(dir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
-                File.Move(origPath, tempPath);
+                SafeMoveFile(origPath, tempPath);
                 renamed = true;
                 string safePkgPath = tempPath;
 
@@ -4910,7 +4948,7 @@ namespace PS4PKGTool
                 {
                     if (renamed && File.Exists(tempPath) && !File.Exists(origPath))
                     {
-                        try { File.Move(tempPath, origPath); } catch { }
+                        try { SafeMoveFile(tempPath, origPath); } catch { }
                     }
                     DeleteOrbisTempDir(tempPath);
                 }
@@ -4920,7 +4958,7 @@ namespace PS4PKGTool
                 // Restore original filename
                 if (renamed && File.Exists(tempPath) && !File.Exists(origPath))
                 {
-                    try { File.Move(tempPath, origPath); }
+                    try { SafeMoveFile(tempPath, origPath); }
                     catch (Exception ex) { Logger.LogError("Failed to restore PKG filename. Recover from " + tempPath + ": " + ex.Message); }
                 }
                 DeleteOrbisTempDir(tempPath);
@@ -5127,7 +5165,7 @@ namespace PS4PKGTool
                         string dir = GetOrbisTempDirFor(origPath);
                         string tempPath = Path.Combine(dir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
                         bool renamed = false;
-                        File.Move(origPath, tempPath);
+                        SafeMoveFile(origPath, tempPath);
                         renamed = true;
                         string pkgPath = tempPath;
 
@@ -5149,41 +5187,37 @@ namespace PS4PKGTool
                             extract.Start();
                             Task<string> extractReadTask = extract.StandardOutput.ReadToEndAsync();
 
-                            // Poll instead of a hard 10-minute kill (issue #76 — large PKGs need longer;
-                            // the old 600000 ms timeout left partial extracts and a stuck "Stop Extract").
+                            // No hard 10-minute kill (issue #76). Poll for cancel; report size every ~3s.
                             int lastMbLogged = -1;
-                            while (!extract.WaitForExit(1000))
-                            {
-                                if (_extractionStopRequested || _extractWorker.CancellationPending)
+                            bool finishedCleanly = WaitForOrbisProcess(
+                                extract,
+                                () => _extractionStopRequested || _extractWorker.CancellationPending,
+                                () =>
                                 {
-                                    try { extract.Kill(entireProcessTree: true); } catch { try { extract.Kill(); } catch { } }
-                                    try { extract.WaitForExit(15000); } catch { }
-                                    break;
-                                }
-                                try
-                                {
-                                    long bytes = 0;
-                                    if (Directory.Exists(tempOutputDir))
+                                    try
                                     {
-                                        foreach (var fi in new DirectoryInfo(tempOutputDir).EnumerateFiles("*", SearchOption.AllDirectories))
-                                            bytes += fi.Length;
+                                        long bytes = 0;
+                                        if (Directory.Exists(tempOutputDir))
+                                        {
+                                            foreach (var fi in new DirectoryInfo(tempOutputDir).EnumerateFiles("*", SearchOption.AllDirectories))
+                                                bytes += fi.Length;
+                                        }
+                                        int mb = (int)(bytes / (1024 * 1024));
+                                        if (mb != lastMbLogged)
+                                        {
+                                            lastMbLogged = mb;
+                                            SetStatus($"Extracting… {mb} MB written (click Stop Extract to cancel)");
+                                        }
                                     }
-                                    int mb = (int)(bytes / (1024 * 1024));
-                                    if (mb != lastMbLogged)
-                                    {
-                                        lastMbLogged = mb;
-                                        SetStatus($"Extracting… {mb} MB written (click Stop Extract to cancel)");
-                                    }
-                                }
-                                catch { }
-                            }
+                                    catch { }
+                                });
+
                             string extractOutput = "";
                             try { extractOutput = extractReadTask.Result; } catch { extractOutput = ""; }
 
                             int exitCode = extract.HasExited ? extract.ExitCode : -1;
-                            // exit -1 = killed process (Stop button) — orbis returns 0 on
-                            // success and 1 on errors, so -1 is the deterministic kill signal.
-                            if (exitCode == -1 || _extractionStopRequested || _extractWorker.CancellationPending)
+                            // Cancelled / killed — orbis returns 0 on success and non-zero on errors.
+                            if (!finishedCleanly || _extractionStopRequested || _extractWorker.CancellationPending)
                             {
                                 e.Cancel = true; // so RunWorkerCompleted shows "Extraction cancelled."
                             }
@@ -5212,10 +5246,7 @@ namespace PS4PKGTool
                                         if (Directory.Exists(entry))
                                             SafeMoveDirectory(entry, dest);
                                         else
-                                        {
-                                            try { if (File.Exists(dest)) File.Delete(dest); } catch (Exception ex) { Logger.LogWarning("Failed to delete dest file: " + ex.Message); }
-                                            File.Move(entry, dest);
-                                        }
+                                            SafeMoveFile(entry, dest);
                                     }
                                 }
                                 if (!e.Cancel)
@@ -5237,7 +5268,7 @@ namespace PS4PKGTool
                                     if (File.Exists(origPath))
                                         Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + tempPath);
                                     else
-                                        File.Move(tempPath, origPath);
+                                        SafeMoveFile(tempPath, origPath);
                                 }
                                 catch (Exception ex)
                                 {
@@ -5376,7 +5407,7 @@ namespace PS4PKGTool
                     string renameDir = GetOrbisTempDirFor(in_path);
                     string renameTmp = Path.Combine(renameDir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
                     bool wasRenamed = false;
-                    File.Move(in_path, renameTmp);
+                    SafeMoveFile(in_path, renameTmp);
                     wasRenamed = true;
                     string safeIn = renameTmp;
 
@@ -5386,7 +5417,7 @@ namespace PS4PKGTool
                     Directory.CreateDirectory(tempBase);
                     string tempOutPath = isDirectory
                         ? tempBase
-                        : Path.Combine(tempBase, Path.GetFileName(out_path));
+                        : Path.Combine(tempBase, Path.GetFileName(out_path).ToOrbisSafeName());
 
                     var extractStartInfo = new ProcessStartInfo
                     {
@@ -5403,20 +5434,19 @@ namespace PS4PKGTool
                     using Process extract = new Process { StartInfo = extractStartInfo };
                     extract.Start();
                     Task<string> extractReadTask = extract.StandardOutput.ReadToEndAsync();
-                    if (!extract.WaitForExit(600000))
-                    {
-                        try { extract.Kill(); extract.WaitForExit(); } catch { }
-                    }
-                    string extractOutput = extractReadTask.Result;
+                    bool finishedCleanly = WaitForOrbisProcess(
+                        extract,
+                        () => _extractionStopRequested || bgw.CancellationPending);
+                    string extractOutput = "";
+                    try { extractOutput = extractReadTask.Result; } catch { extractOutput = ""; }
 
                     try
                     {
-                        int exitCode = extract.ExitCode;
-                        // exit -1 = killed process (Stop button or timeout) — see ExtractFullPKG.
-                        if (exitCode == -1 || _extractionStopRequested || bgw.CancellationPending)
+                        int exitCode = extract.HasExited ? extract.ExitCode : -1;
+                        if (!finishedCleanly || _extractionStopRequested || bgw.CancellationPending)
                         {
-                            // User stopped — the killed process returns a non-zero exit code; not a real failure.
-                            // The outer loop's cancellation check will set args.Cancel and the completion shows "Extraction cancelled."
+                            // User stopped — not a real failure. Outer loop will surface cancel.
+                            args.Cancel = true;
                         }
                         else if (exitCode == 0)
                         {
@@ -5432,10 +5462,7 @@ namespace PS4PKGTool
                                         if (Directory.Exists(entry))
                                             SafeMoveDirectory(entry, dest);
                                         else
-                                        {
-                                            try { if (File.Exists(dest)) File.Delete(dest); } catch (Exception ex) { Logger.LogWarning("Failed to delete dest file: " + ex.Message); }
-                                            File.Move(entry, dest);
-                                        }
+                                            SafeMoveFile(entry, dest);
                                     }
                                 }
                             }
@@ -5446,8 +5473,7 @@ namespace PS4PKGTool
                                     string destDir = Path.GetDirectoryName(out_path);
                                     if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
                                         Directory.CreateDirectory(destDir);
-                                    try { if (File.Exists(out_path)) File.Delete(out_path); } catch (Exception ex) { Logger.LogWarning("Failed to delete output file: " + ex.Message); }
-                                    File.Move(tempOutPath, out_path);
+                                    SafeMoveFile(tempOutPath, out_path);
                                 }
                             }
                             Logger.LogInformation($"File extracted to \"{out_path}\"");
@@ -5468,7 +5494,7 @@ namespace PS4PKGTool
                                 if (File.Exists(in_path))
                                     Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + renameTmp);
                                 else
-                                    File.Move(renameTmp, in_path);
+                                    SafeMoveFile(renameTmp, in_path);
                             }
                             catch (Exception rex)
                             {
@@ -5481,6 +5507,8 @@ namespace PS4PKGTool
 
                     // Clean up temp dir
                     try { if (Directory.Exists(tempBase)) Directory.Delete(tempBase, true); } catch (Exception ex) { Logger.LogWarning("Failed to clean temp base dir: " + ex.Message); }
+
+                    if (args.Cancel) break;
                 }
             };
             bgw.RunWorkerCompleted += delegate (object s, RunWorkerCompletedEventArgs e)
@@ -5525,7 +5553,7 @@ namespace PS4PKGTool
             string renameDir = GetOrbisTempDirFor(inPath);
             string renameTmp = Path.Combine(renameDir, "ps4pkgtool_orbis_" + Guid.NewGuid().ToString("N") + ".pkg");
             bool wasRenamed = false;
-            File.Move(inPath, renameTmp);
+            SafeMoveFile(inPath, renameTmp);
             wasRenamed = true;
             string safeIn = renameTmp;
 
@@ -5569,14 +5597,12 @@ namespace PS4PKGTool
                     using var proc = new Process { StartInfo = extractStartInfo };
                     proc.Start();
                     Task<string> procReadTask = proc.StandardOutput.ReadToEndAsync();
-                    if (!proc.WaitForExit(600000))
-                    {
-                        try { proc.Kill(); proc.WaitForExit(); } catch { }
-                    }
-                    string extractOutput = procReadTask.Result;
-                    int exitCode = proc.ExitCode;
+                    bool finishedCleanly = WaitForOrbisProcess(proc, () => _extractionStopRequested);
+                    string extractOutput = "";
+                    try { extractOutput = procReadTask.Result; } catch { extractOutput = ""; }
+                    int exitCode = proc.HasExited ? proc.ExitCode : -1;
 
-                    if (exitCode == 0)
+                    if (finishedCleanly && exitCode == 0)
                     {
                         if (isDirectory)
                         {
@@ -5589,18 +5615,18 @@ namespace PS4PKGTool
                                     if (Directory.Exists(entry))
                                         SafeMoveDirectory(entry, dest);
                                     else
-                                    {
-                                        try { if (File.Exists(dest)) File.Delete(dest); } catch (Exception ex) { Logger.LogWarning("Failed to delete dest file: " + ex.Message); }
-                                        File.Move(entry, dest);
-                                    }
+                                        SafeMoveFile(entry, dest);
                                 }
                             }
                         }
                         else if (File.Exists(tempOutPath))
                         {
-                            try { if (File.Exists(out_path)) File.Delete(out_path); } catch (Exception ex) { Logger.LogWarning("Failed to delete output file: " + ex.Message); }
-                            File.Move(tempOutPath, out_path);
+                            SafeMoveFile(tempOutPath, out_path);
                         }
+                    }
+                    else if (!finishedCleanly)
+                    {
+                        Logger.LogWarning($"Sync extract cancelled for \"{targ_path}\"");
                     }
                     else
                     {
@@ -5620,7 +5646,7 @@ namespace PS4PKGTool
                         if (File.Exists(inPath))
                             Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + renameTmp);
                         else
-                            File.Move(renameTmp, inPath);
+                            SafeMoveFile(renameTmp, inPath);
                     }
                     catch (Exception rex)
                     {
@@ -5865,7 +5891,7 @@ namespace PS4PKGTool
 
             try
             {
-                File.Move(origPath, renameTmp);
+                SafeMoveFile(origPath, renameTmp);
                 renamed = true;
                 tempDir = CreateOrbisTempDir("c"); // short ASCII temp root (see CreateOrbisTempDir)
                 string orbisPubCmdErrorMessage = "";
@@ -5889,11 +5915,14 @@ namespace PS4PKGTool
                 extract.Start();
                 extract.BeginErrorReadLine();
                 Task<string> extractStdoutTask = extract.StandardOutput.ReadToEndAsync();
-                if (!extract.WaitForExit(600000))
+                // changeinfo is tiny; 2-minute cap is enough, still respects no infinite hang
+                if (!extract.WaitForExit(120000))
                 {
-                    try { extract.Kill(); extract.WaitForExit(); } catch { }
+                    try { extract.Kill(entireProcessTree: true); } catch { try { extract.Kill(); } catch { } }
+                    try { extract.WaitForExit(10000); } catch { }
                 }
-                string extractStdout = extractStdoutTask.Result;
+                string extractStdout = "";
+                try { extractStdout = extractStdoutTask.Result; } catch { extractStdout = ""; }
 
                 foreach (string line in extractStdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
                 {
@@ -5936,7 +5965,7 @@ namespace PS4PKGTool
                         if (File.Exists(origPath))
                             Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + renameTmp);
                         else
-                            File.Move(renameTmp, origPath);
+                            SafeMoveFile(renameTmp, origPath);
                     }
                     catch (Exception rex)
                     {
@@ -6840,9 +6869,10 @@ namespace PS4PKGTool
         /// </summary>
         private static string FormatPkgSystemVersion(int value)
         {
-            if (value == 0) return "0";
-            int major = (value >> 24) & 0xFF;
-            int minor = (value >> 16) & 0xFF;
+            uint v = unchecked((uint)value);
+            if (v == 0) return "0";
+            int major = (int)((v >> 24) & 0xFF);
+            int minor = (int)((v >> 16) & 0xFF);
             return $"{major}.{minor:X2}";
         }
 

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -2126,9 +2126,8 @@ namespace PS4PKGTool
                         {
                             if (t.Name == "SYSTEM_VER")
                             {
-                                int value = Convert.ToInt32(t.Value);
-                                if (value != 0)
-                                    pkgMinFirmware = $"{(value >> 8) & 0xFF}.{value & 0xFF:D2}";
+                                if (int.TryParse(t.Value, out int value) && value != 0)
+                                    pkgMinFirmware = FormatPkgSystemVersion(value);
                                 else pkgMinFirmware = t.Value;
                             }
                             if (t.Name == "VERSION") pkgVersion = verRegex2.Replace(t.Value, "");
@@ -2333,31 +2332,46 @@ namespace PS4PKGTool
                 var PkgDirectoryList = appSettings_.PkgDirectories;
                 foreach (var directory in PkgDirectoryList)
                 {
-                    var searchOption = appSettings_.ScanRecursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-
+                    // Non-recursive: only the configured folder itself (not children).
+                    // Recursive: whole tree, skipping excluded top-level folder names.
                     try
                     {
-                        var allDirectories = Directory.GetDirectories(directory, "*", SearchOption.TopDirectoryOnly);
-
-                        var directoriesToScan = new List<string> { directory };
-                        directoriesToScan.AddRange(allDirectories.Where(dir => !ExcludedDirectoryList.Contains(Path.GetFileName(dir))));
-
-                        foreach (var directory_ in directoriesToScan)
+                        if (!appSettings_.ScanRecursive)
                         {
                             this.Invoke((MethodInvoker)delegate
                             {
-                                toolStripStatusLabel2.Text = "Scanning directory.. " + "(" + directory_ + ") ";
+                                toolStripStatusLabel2.Text = "Scanning directory.. " + "(" + directory + ") ";
                             });
-
                             try
                             {
-                                var pkgFiles = Directory.EnumerateFiles(directory_, "*.PKG", searchOption);
-                                PkgFileList.AddRange(pkgFiles);
+                                PkgFileList.AddRange(Directory.EnumerateFiles(directory, "*.PKG", SearchOption.TopDirectoryOnly));
                             }
                             catch (UnauthorizedAccessException e)
                             {
                                 Logger.LogError(e.Message);
                             }
+                            continue;
+                        }
+
+                        this.Invoke((MethodInvoker)delegate
+                        {
+                            toolStripStatusLabel2.Text = "Scanning directory.. " + "(" + directory + ") ";
+                        });
+                        try
+                        {
+                            foreach (string pkgPath in Directory.EnumerateFiles(directory, "*.PKG", SearchOption.AllDirectories))
+                            {
+                                // Skip files under excluded directory names (any path segment)
+                                string[] parts = pkgPath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                                if (parts.Any(p => ExcludedDirectoryList.Any(ex =>
+                                        string.Equals(ex, p, StringComparison.OrdinalIgnoreCase))))
+                                    continue;
+                                PkgFileList.Add(pkgPath);
+                            }
+                        }
+                        catch (UnauthorizedAccessException e)
+                        {
+                            Logger.LogError(e.Message);
                         }
                     }
                     catch (UnauthorizedAccessException e)
@@ -2473,9 +2487,8 @@ namespace PS4PKGTool
                     {
                         if (t.Name == "SYSTEM_VER")
                         {
-                            int value = Convert.ToInt32(t.Value);
-                            if (value != 0)
-                                pkgSystemVersion = $"{(value >> 8) & 0xFF}.{value & 0xFF:D2}";
+                            if (int.TryParse(t.Value, out int value) && value != 0)
+                                pkgSystemVersion = FormatPkgSystemVersion(value);
                             else pkgSystemVersion = t.Value;
                         }
                         if (t.Name == "VERSION")
@@ -5077,6 +5090,18 @@ namespace PS4PKGTool
                     listView1?.Refresh();
                     _extractWorker.DoWork += (sender, e) =>
                     {
+                        void SetStatus(string text)
+                        {
+                            try
+                            {
+                                this.BeginInvoke((Action)(() =>
+                                {
+                                    toolStripStatusLabel2.Text = text;
+                                }));
+                            }
+                            catch { }
+                        }
+
                         this.Invoke((Action)(() =>
                         {
                             toolStripProgressBar1.Visible = true;
@@ -5088,7 +5113,7 @@ namespace PS4PKGTool
                         string origPath = PKG.SelectedPKGFilename;
                         Logger.LogInformation($"Extracting: {Path.GetFileName(origPath)}");
                         Logger.LogInformation($"Extracting PKG ({origPath})..");
-                        toolStripStatusLabel2.Text = $"Extracting PKG ({origPath})..";
+                        SetStatus($"Extracting PKG ({Path.GetFileName(origPath)})…");
                         extractLocation = $@"{extractLocation}\{PS4_PKG.PS4_Title.SanitizeFileName()}";
                         Tool.CreateDirectoryIfNotExists(extractLocation);
 
@@ -5123,14 +5148,40 @@ namespace PS4PKGTool
                             using Process extract = new Process { StartInfo = extractStartInfo };
                             extract.Start();
                             Task<string> extractReadTask = extract.StandardOutput.ReadToEndAsync();
-                            if (!extract.WaitForExit(600000))
-                            {
-                                try { extract.Kill(); extract.WaitForExit(); } catch { }
-                            }
-                            string extractOutput = extractReadTask.Result;
 
-                            int exitCode = extract.ExitCode;
-                            // exit -1 = killed process (Stop button or timeout) — orbis returns 0 on
+                            // Poll instead of a hard 10-minute kill (issue #76 — large PKGs need longer;
+                            // the old 600000 ms timeout left partial extracts and a stuck "Stop Extract").
+                            int lastMbLogged = -1;
+                            while (!extract.WaitForExit(1000))
+                            {
+                                if (_extractionStopRequested || _extractWorker.CancellationPending)
+                                {
+                                    try { extract.Kill(entireProcessTree: true); } catch { try { extract.Kill(); } catch { } }
+                                    try { extract.WaitForExit(15000); } catch { }
+                                    break;
+                                }
+                                try
+                                {
+                                    long bytes = 0;
+                                    if (Directory.Exists(tempOutputDir))
+                                    {
+                                        foreach (var fi in new DirectoryInfo(tempOutputDir).EnumerateFiles("*", SearchOption.AllDirectories))
+                                            bytes += fi.Length;
+                                    }
+                                    int mb = (int)(bytes / (1024 * 1024));
+                                    if (mb != lastMbLogged)
+                                    {
+                                        lastMbLogged = mb;
+                                        SetStatus($"Extracting… {mb} MB written (click Stop Extract to cancel)");
+                                    }
+                                }
+                                catch { }
+                            }
+                            string extractOutput = "";
+                            try { extractOutput = extractReadTask.Result; } catch { extractOutput = ""; }
+
+                            int exitCode = extract.HasExited ? extract.ExitCode : -1;
+                            // exit -1 = killed process (Stop button) — orbis returns 0 on
                             // success and 1 on errors, so -1 is the deterministic kill signal.
                             if (exitCode == -1 || _extractionStopRequested || _extractWorker.CancellationPending)
                             {
@@ -5145,10 +5196,17 @@ namespace PS4PKGTool
                             else
                             {
                                 // Move extracted files from ASCII temp dir to actual output path
+                                // (cross-drive moves copy every file — can take a long time; update UI)
+                                SetStatus($"Moving extracted files to \"{extractLocation}\"…");
                                 if (Directory.Exists(tempOutputDir))
                                 {
                                     foreach (string entry in Directory.GetFileSystemEntries(tempOutputDir))
                                     {
+                                        if (_extractionStopRequested || _extractWorker.CancellationPending)
+                                        {
+                                            e.Cancel = true;
+                                            break;
+                                        }
                                         string dest = Path.Combine(extractLocation, Path.GetFileName(entry));
                                         try { if (Directory.Exists(dest)) Directory.Delete(dest, true); } catch (Exception ex) { Logger.LogWarning("Failed to delete dest dir: " + ex.Message); }
                                         if (Directory.Exists(entry))
@@ -5160,9 +5218,11 @@ namespace PS4PKGTool
                                         }
                                     }
                                 }
-                                Logger.LogInformation($"PKG extracted to \"{extractLocation}\".");
-
-                                this.Invoke(() => ShowInformation($"PKG extracted.", false));
+                                if (!e.Cancel)
+                                {
+                                    Logger.LogInformation($"PKG extracted to \"{extractLocation}\".");
+                                    this.Invoke(() => ShowInformation($"PKG extracted.", false));
+                                }
                             }
 
                             // Clean up temp output dir
@@ -6524,79 +6584,103 @@ namespace PS4PKGTool
 
         private void PKGListGridView_CellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
         {
-            if (e.ColumnIndex != 0)
-                e.CellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
-
-            // Apply color label to this specific row only (not the entire grid)
-            if (appSettings_.PkgColorLabel && e.RowIndex >= 0 && e.RowIndex < PKGGridView.Rows.Count)
+            try
             {
+                if (e.ColumnIndex != 0 && e.CellStyle != null)
+                    e.CellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
+
+                // Apply color label to this specific row only (not the entire grid)
+                if (appSettings_ == null || !appSettings_.PkgColorLabel) return;
+                if (e.RowIndex < 0 || e.RowIndex >= PKGGridView.Rows.Count) return;
+
                 var row = PKGGridView.Rows[e.RowIndex];
-                if (row.Cells[8].Value == null) return;
-                string category = row.Cells[8].Value.ToString();
-                Color fore, back;
-                switch (category)
-                {
-                    case PKGCategory.PATCH:
-                        fore = appSettings_.PatchPkgForeColor;
-                        back = appSettings_.PatchPkgBackColor;
-                        break;
-                    case PKGCategory.GAME:
-                        fore = appSettings_.GamePkgForeColor;
-                        back = appSettings_.GamePkgBackColor;
-                        break;
-                    case PKGCategory.ADDON:
-                        fore = appSettings_.AddonPkgForeColor;
-                        back = appSettings_.AddonPkgBackColor;
-                        break;
-                    case PKGCategory.APP:
-                        fore = appSettings_.AppPkgForeColor;
-                        back = appSettings_.AppPkgBackColor;
-                        break;
-                    default:
-                        return;
-                }
+                if (!TryGetRowCategory(row, out string category)) return;
+                if (!TryGetCategoryColors(category, out Color fore, out Color back)) return;
                 e.CellStyle.ForeColor = fore;
                 e.CellStyle.BackColor = back;
+            }
+            catch
+            {
+                // Never let paint-time formatting crash the grid (issues #65 / #74)
+            }
+        }
+
+        private static bool TryGetRowCategory(DataGridViewRow row, out string category)
+        {
+            category = null;
+            if (row == null || row.IsNewRow) return false;
+            try
+            {
+                object value = null;
+                if (row.DataGridView?.Columns.Contains("Category") == true)
+                    value = row.Cells["Category"].Value;
+                else if (row.Cells.Count > 8)
+                    value = row.Cells[8].Value;
+                category = value?.ToString();
+                return !string.IsNullOrEmpty(category);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private bool TryGetCategoryColors(string category, out Color fore, out Color back)
+        {
+            fore = default;
+            back = default;
+            if (appSettings_ == null) return false;
+            switch (category)
+            {
+                case PKGCategory.PATCH:
+                    fore = appSettings_.PatchPkgForeColor;
+                    back = appSettings_.PatchPkgBackColor;
+                    return true;
+                case PKGCategory.GAME:
+                    fore = appSettings_.GamePkgForeColor;
+                    back = appSettings_.GamePkgBackColor;
+                    return true;
+                case PKGCategory.ADDON:
+                    fore = appSettings_.AddonPkgForeColor;
+                    back = appSettings_.AddonPkgBackColor;
+                    return true;
+                case PKGCategory.APP:
+                    fore = appSettings_.AppPkgForeColor;
+                    back = appSettings_.AppPkgBackColor;
+                    return true;
+                default:
+                    return false;
             }
         }
 
         private void UpdatePKGColorLabel()
         {
-            if (appSettings_.PkgColorLabel)
+            try
             {
-                foreach (DataGridViewRow row in PKGGridView.Rows)
+                if (PKGGridView == null || appSettings_ == null) return;
+                if (appSettings_.PkgColorLabel)
                 {
-                    if (row.IsNewRow || row.Cells[8].Value == null) continue;
-                    string category = row.Cells[8].Value.ToString();
-
-                    switch (category)
+                    foreach (DataGridViewRow row in PKGGridView.Rows)
                     {
-                        case PKGCategory.PATCH:
-                            row.DefaultCellStyle.ForeColor = appSettings_.PatchPkgForeColor;
-                            row.DefaultCellStyle.BackColor = appSettings_.PatchPkgBackColor;
-                            break;
-                        case PKGCategory.GAME:
-                            row.DefaultCellStyle.ForeColor = appSettings_.GamePkgForeColor;
-                            row.DefaultCellStyle.BackColor = appSettings_.GamePkgBackColor;
-                            break;
-                        case PKGCategory.ADDON:
-                            row.DefaultCellStyle.ForeColor = appSettings_.AddonPkgForeColor;
-                            row.DefaultCellStyle.BackColor = appSettings_.AddonPkgBackColor;
-                            break;
-                        case PKGCategory.APP:
-                            row.DefaultCellStyle.ForeColor = appSettings_.AppPkgForeColor;
-                            row.DefaultCellStyle.BackColor = appSettings_.AppPkgBackColor;
-                            break;
+                        if (!TryGetRowCategory(row, out string category)) continue;
+                        if (!TryGetCategoryColors(category, out Color fore, out Color back)) continue;
+                        row.DefaultCellStyle.ForeColor = fore;
+                        row.DefaultCellStyle.BackColor = back;
+                    }
+                }
+                else
+                {
+                    foreach (DataGridViewRow row in PKGGridView.Rows)
+                    {
+                        if (row.IsNewRow) continue;
+                        var isOdd = (row.Index % 2 != 0);
+                        row.DefaultCellStyle = GetCellStyle(isFocused: false, isOdd, isHeader: false);
                     }
                 }
             }
-            else
+            catch (Exception ex)
             {
-                foreach (DataGridViewRow row in PKGGridView.Rows)
-                {
-                    var isOdd = (row.Index % 2 != 0);
-                    row.DefaultCellStyle = GetCellStyle(isFocused: false, isOdd, isHeader: false);
-                }
+                Logger.LogWarning("UpdatePKGColorLabel failed: " + ex.Message);
             }
         }
 
@@ -6621,6 +6705,9 @@ namespace PS4PKGTool
                 string colName = PKGGridView.Columns[e.ColumnIndex].Name;
                 if (string.IsNullOrEmpty(colName)) return;
 
+                // Preserve active search/filter across DataSource swap (issue #65)
+                string savedFilter = dataTable.DefaultView.RowFilter ?? string.Empty;
+
                 // Region column (byte[]) needs special handling
                 if (colName == "Region")
                 {
@@ -6640,6 +6727,7 @@ namespace PS4PKGTool
                     {
                         "Size" => r => ParseSizeToBytes(r["Size"]?.ToString()),
                         "System Version" => r => ParseVersion(r["System Version"]?.ToString() ?? ""),
+                        "Title ID" => _ => 0,
                         _ => r => ParseAppVersion(r["Version [App Version]"]?.ToString() ?? "")
                     };
                     var sorted = dataTable.Rows.Cast<DataRow>().ToList();
@@ -6651,10 +6739,7 @@ namespace PS4PKGTool
                     if (numNext == SortOrder.Descending) sorted.Reverse();
                     var newTable = dataTable.Clone();
                     foreach (var r in sorted) newTable.Rows.Add(r.ItemArray);
-                    PKGGridView.DataSource = newTable;
-                    ScrollToTop();
-                    UpdateDataGridViewColumnVisibility();
-                    PKGGridView.Columns[e.ColumnIndex].HeaderCell.SortGlyphDirection = numNext;
+                    ApplySortedTable(newTable, savedFilter, e.ColumnIndex, numNext);
                     return;
                 }
 
@@ -6669,9 +6754,7 @@ namespace PS4PKGTool
                 if (next == SortOrder.Descending) sortedRows.Reverse();
                 var sortedTable = dataTable.Clone();
                 foreach (var r in sortedRows) sortedTable.Rows.Add(r.ItemArray);
-                PKGGridView.DataSource = sortedTable;
-                ScrollToTop();
-                PKGGridView.Columns[e.ColumnIndex].HeaderCell.SortGlyphDirection = next;
+                ApplySortedTable(sortedTable, savedFilter, e.ColumnIndex, next);
             }
             catch (Exception ex)
             {
@@ -6680,13 +6763,50 @@ namespace PS4PKGTool
             }
         }
 
+        private void ApplySortedTable(DataTable sortedTable, string savedFilter, int columnIndex, SortOrder glyph)
+        {
+            PKGGridView.DataSource = sortedTable;
+            try
+            {
+                if (!string.IsNullOrEmpty(savedFilter))
+                    sortedTable.DefaultView.RowFilter = savedFilter;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Could not re-apply grid filter after sort: " + ex.Message);
+            }
+            UpdateDataGridViewColumnVisibility();
+            UpdatePKGColorLabel();
+            ScrollToTop();
+            if (columnIndex >= 0 && columnIndex < PKGGridView.Columns.Count)
+                PKGGridView.Columns[columnIndex].HeaderCell.SortGlyphDirection = glyph;
+            PopulateGroupedView();
+        }
+
         private void ScrollToTop()
         {
-            if (PKGGridView.Rows.Count > 0)
+            try
             {
-                PKGGridView.Rows[0].Selected = true;
-                PKGGridView.CurrentCell = PKGGridView.Rows[0].Cells[0];
-                try { PKGGridView.FirstDisplayedScrollingRowIndex = 0; } catch (Exception ex) { Logger.LogWarning("Failed to scroll grid to top: " + ex.Message); }
+                if (PKGGridView.Rows.Count == 0) return;
+                // Prefer a visible cell — hidden column 0 would throw when setting CurrentCell
+                DataGridViewRow row = PKGGridView.Rows[0];
+                DataGridViewCell cell = null;
+                foreach (DataGridViewCell c in row.Cells)
+                {
+                    if (c.Visible && c.OwningColumn.Visible)
+                    {
+                        cell = c;
+                        break;
+                    }
+                }
+                if (cell == null) return;
+                row.Selected = true;
+                PKGGridView.CurrentCell = cell;
+                PKGGridView.FirstDisplayedScrollingRowIndex = 0;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Failed to scroll grid to top: " + ex.Message);
             }
         }
 
@@ -6714,9 +6834,22 @@ namespace PS4PKGTool
             return a.Length.CompareTo(b.Length);
         }
 
+        /// <summary>
+        /// Decode param.sfo SYSTEM_VER (e.g. 0x0A500000 → "10.50").
+        /// Previous formula used the low 16 bits and showed 10.50 as 1.05 / 0.00.
+        /// </summary>
+        private static string FormatPkgSystemVersion(int value)
+        {
+            if (value == 0) return "0";
+            int major = (value >> 24) & 0xFF;
+            int minor = (value >> 16) & 0xFF;
+            return $"{major}.{minor:X2}";
+        }
+
         private static double ParseVersion(string ver)
         {
             // "4.50" -> 4.5, "11.00" -> 11.0
+            // Minor is hex digits in display (10.50), so parse "10.50" as decimal major.minor text.
             if (string.IsNullOrEmpty(ver) || ver == "NA") return -1;
             if (double.TryParse(ver, System.Globalization.NumberStyles.Any,
                 System.Globalization.CultureInfo.InvariantCulture, out double v)) return v;
@@ -6881,16 +7014,22 @@ namespace PS4PKGTool
             {
                 var dt = PKGGridView.DataSource as DataTable;
                 if (dt == null) return;
-                string text = tbSearchGame.Text.Replace("'", "''"); // escape single quotes for LIKE
-                dt.DefaultView.RowFilter = string.IsNullOrEmpty(text)
+                // Escape LIKE wildcards and quotes so filter text cannot break RowFilter (issue #65)
+                string text = (tbSearchGame.Text ?? "")
+                    .Replace("'", "''")
+                    .Replace("[", "[[]")
+                    .Replace("%", "[%]")
+                    .Replace("*", "[*]");
+                dt.DefaultView.RowFilter = string.IsNullOrEmpty(tbSearchGame.Text)
                     ? string.Empty
                     : $"[Filename] LIKE '%{text}%' OR [Title] LIKE '%{text}%' OR [Title ID] LIKE '%{text}%' OR [Content ID] LIKE '%{text}%'";
+                try { UpdatePKGColorLabel(); } catch { }
                 PopulateGroupedView(); // GLV mirrors the search result set
             }
             catch (Exception ex)
             {
                 Logger.LogError($"Error applying filter: {ex.Message}");
-                ShowError($"Error applying filter: {ex.Message}", true);
+                // Do not ShowError on every keystroke — log only to avoid modal spam mid-typing
             }
         }
 

--- a/PS4PKGTool/Forms/Main/Main.cs
+++ b/PS4PKGTool/Forms/Main/Main.cs
@@ -5230,16 +5230,28 @@ namespace PS4PKGTool
                             try { extractOutput = extractReadTask.Result; } catch { extractOutput = ""; }
 
                             int exitCode = extract.HasExited ? extract.ExitCode : -1;
-                            // Cancelled / killed — orbis returns 0 on success and non-zero on errors.
-                            if (!finishedCleanly || _extractionStopRequested || _extractWorker.CancellationPending)
+                            // Stop button kills orbis externally — treat any cancel flag as user stop,
+                            // not an orbis error (avoids "(no output from orbis-pub-cmd)" on Stop).
+                            bool userCancelled = !finishedCleanly
+                                || _extractionStopRequested
+                                || _extractWorker.CancellationPending;
+                            if (userCancelled)
                             {
-                                e.Cancel = true; // so RunWorkerCompleted shows "Extraction cancelled."
+                                e.Cancel = true; // RunWorkerCompleted → "Extraction cancelled."
                             }
                             else if (exitCode != 0)
                             {
-                                string errMsg = FormatOrbisError(extractOutput);
-                                Logger.LogError($"orbis-pub-cmd exit code: {exitCode}, cancelPending={_extractWorker.CancellationPending}\n{errMsg}");
-                                this.Invoke(() => ShowError($"orbis-pub-cmd error:\n{errMsg}", true));
+                                // Re-check: KillProcess may have exited the process before the flag was visible.
+                                if (_extractionStopRequested || _extractWorker.CancellationPending)
+                                {
+                                    e.Cancel = true;
+                                }
+                                else
+                                {
+                                    string errMsg = FormatOrbisError(extractOutput);
+                                    Logger.LogError($"orbis-pub-cmd exit code: {exitCode}, cancelPending={_extractWorker.CancellationPending}\n{errMsg}");
+                                    this.Invoke(() => ShowError($"orbis-pub-cmd error:\n{errMsg}", true));
+                                }
                             }
                             else
                             {
@@ -6915,17 +6927,18 @@ namespace PS4PKGTool
             bool anyRunning = false;
             if (_extractWorker != null && _extractWorker.IsBusy)
             {
-                KillProcess("orbis-pub-cmd");
-                Helper.IsOperationRunning = false;
+                // Set cancel flag BEFORE killing orbis so the worker never treats a kill as a hard error.
                 _extractionStopRequested = true; // volatile — reliable across the worker thread
+                Helper.IsOperationRunning = false;
                 _extractWorker.CancelAsync();
+                KillProcess("orbis-pub-cmd");
                 anyRunning = true;
             }
             if (_selectedExtractWorker != null && _selectedExtractWorker.IsBusy)
             {
-                KillProcess("orbis-pub-cmd");
                 _extractionStopRequested = true; // volatile — reliable across the worker thread
                 _selectedExtractWorker.CancelAsync();
+                KillProcess("orbis-pub-cmd");
                 anyRunning = true;
             }
             if (anyRunning)

--- a/PS4PKGTool/Forms/Official Update/OfficialUpdateForm.cs
+++ b/PS4PKGTool/Forms/Official Update/OfficialUpdateForm.cs
@@ -335,14 +335,12 @@ namespace PS4PKGTool
 
             try
             {
+                // SYSTEM_VER is packed as 0xMMmm0000 → major.minor (e.g. 0x0A500000 → 10.50)
                 int value = Convert.ToInt32(sysVer);
-                string hex = string.Format("{0:X}", value);
-                if (hex.Length >= 3)
-                {
-                    string f3 = hex.Substring(0, 3);
-                    return f3.Insert(1, ".");
-                }
-                return hex;
+                if (value == 0) return "0";
+                int major = (value >> 24) & 0xFF;
+                int minor = (value >> 16) & 0xFF;
+                return $"{major}.{minor:X2}";
             }
             catch
             {

--- a/PS4PKGTool/Forms/Program Settings/Program Settings.Designer.cs
+++ b/PS4PKGTool/Forms/Program Settings/Program Settings.Designer.cs
@@ -1045,7 +1045,7 @@ namespace PS4PKGTool
             grpTrophyCache.Location = new System.Drawing.Point(12, 16);
             grpTrophyCache.Name = "grpTrophyCache";
             grpTrophyCache.SectionHeader = "Trophy Metadata Cache";
-            grpTrophyCache.Size = new System.Drawing.Size(606, 205);
+            grpTrophyCache.Size = new System.Drawing.Size(606, 280);
             grpTrophyCache.TabIndex = 0;
             // 
             // lblTrophyCacheDesc
@@ -1054,14 +1054,14 @@ namespace PS4PKGTool
             lblTrophyCacheDesc.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
             lblTrophyCacheDesc.Location = new System.Drawing.Point(15, 32);
             lblTrophyCacheDesc.Name = "lblTrophyCacheDesc";
-            lblTrophyCacheDesc.Size = new System.Drawing.Size(575, 38);
+            lblTrophyCacheDesc.Size = new System.Drawing.Size(575, 72);
             lblTrophyCacheDesc.TabIndex = 0;
-            lblTrophyCacheDesc.Text = "Extract NP Communication IDs from PKGs in the configured directories.\r\nCached IDs enable full trophy names and descriptions when a PKG is selected.";
+            lblTrophyCacheDesc.Text = "Trophy names are encrypted. This cache stores each game's NP Communication ID so names and descriptions can decrypt.\r\n\r\n1. On the General tab, add your PKG folder(s).\r\n2. Click Build below to scan those folders once.\r\n3. Select a game in the main window and open the Trophy tab.";
             // 
             // btnBuildTrophyCache
             // 
             btnBuildTrophyCache.Font = new System.Drawing.Font("Segoe UI", 9F);
-            btnBuildTrophyCache.Location = new System.Drawing.Point(15, 78);
+            btnBuildTrophyCache.Location = new System.Drawing.Point(15, 112);
             btnBuildTrophyCache.Name = "btnBuildTrophyCache";
             btnBuildTrophyCache.Size = new System.Drawing.Size(210, 30);
             btnBuildTrophyCache.TabIndex = 1;
@@ -1070,8 +1070,9 @@ namespace PS4PKGTool
             // 
             // btnCancelTrophyCache
             // 
+            btnCancelTrophyCache.Enabled = false;
             btnCancelTrophyCache.Font = new System.Drawing.Font("Segoe UI", 9F);
-            btnCancelTrophyCache.Location = new System.Drawing.Point(235, 78);
+            btnCancelTrophyCache.Location = new System.Drawing.Point(235, 112);
             btnCancelTrophyCache.Name = "btnCancelTrophyCache";
             btnCancelTrophyCache.Size = new System.Drawing.Size(105, 30);
             btnCancelTrophyCache.TabIndex = 2;
@@ -1081,7 +1082,7 @@ namespace PS4PKGTool
             // btnClearTrophyCache
             // 
             btnClearTrophyCache.Font = new System.Drawing.Font("Segoe UI", 9F);
-            btnClearTrophyCache.Location = new System.Drawing.Point(350, 78);
+            btnClearTrophyCache.Location = new System.Drawing.Point(350, 112);
             btnClearTrophyCache.Name = "btnClearTrophyCache";
             btnClearTrophyCache.Size = new System.Drawing.Size(120, 30);
             btnClearTrophyCache.TabIndex = 3;
@@ -1090,19 +1091,21 @@ namespace PS4PKGTool
             // 
             // pbTrophyCacheProgress
             // 
-            pbTrophyCacheProgress.Location = new System.Drawing.Point(15, 120);
+            pbTrophyCacheProgress.Location = new System.Drawing.Point(15, 156);
             pbTrophyCacheProgress.Maximum = 1;
             pbTrophyCacheProgress.Name = "pbTrophyCacheProgress";
             pbTrophyCacheProgress.Size = new System.Drawing.Size(575, 20);
+            pbTrophyCacheProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             pbTrophyCacheProgress.TabIndex = 4;
+            pbTrophyCacheProgress.Visible = false;
             // 
             // lblTrophyCacheStatus
             // 
             lblTrophyCacheStatus.Font = new System.Drawing.Font("Segoe UI", 9F);
             lblTrophyCacheStatus.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
-            lblTrophyCacheStatus.Location = new System.Drawing.Point(15, 150);
+            lblTrophyCacheStatus.Location = new System.Drawing.Point(15, 186);
             lblTrophyCacheStatus.Name = "lblTrophyCacheStatus";
-            lblTrophyCacheStatus.Size = new System.Drawing.Size(575, 42);
+            lblTrophyCacheStatus.Size = new System.Drawing.Size(575, 72);
             lblTrophyCacheStatus.TabIndex = 5;
             lblTrophyCacheStatus.Text = "Cache not checked.";
             // 

--- a/PS4PKGTool/Forms/Program Settings/Program Settings.cs
+++ b/PS4PKGTool/Forms/Program Settings/Program Settings.cs
@@ -477,12 +477,17 @@ namespace PS4PKGTool
             List<string> directories = lbPkgDirectoryList.Items.Cast<string>().ToList();
             if (directories.Count == 0)
             {
-                ShowWarning("Add at least one PKG directory before building the trophy metadata cache.", false);
+                ShowWarning(
+                    "No PKG folders are configured yet.\n\n" +
+                    "1. Open the General tab\n" +
+                    "2. Add at least one folder that contains your .pkg files\n" +
+                    "3. Return here and click Build Trophy Metadata Cache",
+                    false);
                 return;
             }
             if (!File.Exists(OrbisPubCmd))
             {
-                ShowError("Missing orbis-pub-cmd.exe in AppData.", true);
+                ShowError("Missing orbis-pub-cmd.exe in AppData. Reinstall or restore the AppData tools folder.", true);
                 return;
             }
 
@@ -492,8 +497,10 @@ namespace PS4PKGTool
             btnClearTrophyCache.Enabled = false;
             btnCancelTrophyCache.Enabled = true;
             btnSaveClose.Enabled = false;
-            lblTrophyCacheStatus.Text = "Scanning configured PKG directories...";
+            pbTrophyCacheProgress.Visible = true;
             pbTrophyCacheProgress.Value = 0;
+            pbTrophyCacheProgress.Maximum = 1;
+            lblTrophyCacheStatus.Text = "Scanning configured PKG directories...";
 
             var progress = new Progress<TrophyCacheProgress>(value =>
             {
@@ -517,10 +524,13 @@ namespace PS4PKGTool
                     progress,
                     trophyCacheCancellation.Token);
 
-                string summary = $"PKGs: {result.TotalPackages} | Added: {result.Added} | Cached: {result.AlreadyCached} | " +
+                string summary = $"PKGs: {result.TotalPackages} | Added: {result.Added} | Already cached: {result.AlreadyCached} | " +
                     $"No trophies: {result.WithoutTrophies} | Duplicates: {result.DuplicateContentIds} | Failed: {result.Failed}";
-                lblTrophyCacheStatus.Text = (result.Cancelled ? "Cancelled. " : "Complete. ") + summary;
-                Logger.LogInformation("Trophy metadata cache: " + lblTrophyCacheStatus.Text);
+                lblTrophyCacheStatus.Text = (result.Cancelled ? "Cancelled. " : "Complete. ") + summary +
+                    (result.Added + result.AlreadyCached > 0
+                        ? "\nSelect a game in the main window and open the Trophy tab to see names."
+                        : string.Empty);
+                Logger.LogInformation("Trophy metadata cache: " + summary);
                 foreach (string error in result.Errors)
                     Logger.LogWarning("Trophy cache: " + error);
 
@@ -539,17 +549,21 @@ namespace PS4PKGTool
                 btnClearTrophyCache.Enabled = true;
                 btnCancelTrophyCache.Enabled = false;
                 btnSaveClose.Enabled = true;
+                pbTrophyCacheProgress.Visible = false;
             }
         }
 
         private void btnCancelTrophyCache_Click(object sender, EventArgs e)
         {
+            if (btnBuildTrophyCache.Enabled)
+                return;
             trophyCacheCancellation?.Cancel();
+            lblTrophyCacheStatus.Text = "Cancelling...";
         }
 
         private void btnClearTrophyCache_Click(object sender, EventArgs e)
         {
-            if (DialogResultYesNo("Clear every cached NP Communication ID?") != DialogResult.Yes)
+            if (DialogResultYesNo("Clear every cached NP Communication ID?\n\nTrophy names will need to be decrypted again after the next cache build.") != DialogResult.Yes)
                 return;
             try
             {
@@ -568,7 +582,19 @@ namespace PS4PKGTool
             try
             {
                 int count = new NpCommunicationIdCache(TrophyCachePath).Count;
-                lblTrophyCacheStatus.Text = $"Cached NP Communication IDs: {count}";
+                int directoryCount = lbPkgDirectoryList.Items.Count;
+                if (count == 0)
+                {
+                    lblTrophyCacheStatus.Text = directoryCount == 0
+                        ? "Cache empty. Add PKG folders on the General tab, then click Build."
+                        : $"Cache empty ({directoryCount} PKG folder{(directoryCount == 1 ? "" : "s")} configured). Click Build to scan them.";
+                }
+                else
+                {
+                    lblTrophyCacheStatus.Text =
+                        $"Cached NP Communication IDs: {count}\n" +
+                        "Trophy names will load automatically when you select a game.";
+                }
             }
             catch (Exception ex)
             {

--- a/PS4PKGTool/IllegalNameCheck.cs
+++ b/PS4PKGTool/IllegalNameCheck.cs
@@ -32,6 +32,18 @@ namespace PS4PKGTool
             return (Regex.IsMatch(expression, sPattern, RegexOptions.CultureInvariant));
         }
 
+        /// <summary>True when every character is ASCII (code point &lt; 128). orbis-pub-cmd rejects non-ASCII paths.</summary>
+        public static bool IsAsciiPath(this string path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            for (int i = 0; i < path.Length; i++)
+            {
+                if (path[i] >= 128)
+                    return false;
+            }
+            return true;
+        }
+
         /// <summary>Replaces NTFS-invalid characters with visually-similar Unicode alternatives.</summary>
         public static string SanitizeFileName(this string name)
         {
@@ -60,6 +72,34 @@ namespace PS4PKGTool
                 result = "_" + result;
 
             return string.IsNullOrEmpty(result) ? "_" : result;
+        }
+
+        /// <summary>
+        /// Builds a folder name safe for tools that choke on non-ASCII paths.
+        /// Keeps ASCII letters/digits/space/dash/underscore/dot/apostrophe; maps other chars to '_'.
+        /// Prefer using ASCII temp dirs for orbis I/O and only apply this when a path must be fed to orbis.
+        /// </summary>
+        public static string ToOrbisSafeName(this string name)
+        {
+            if (string.IsNullOrEmpty(name)) return "_";
+
+            var sb = new StringBuilder(name.Length);
+            foreach (char c in name)
+            {
+                if (c < 128 && (char.IsLetterOrDigit(c) || c is ' ' or '-' or '_' or '.' or '\'' or '[' or ']' or '(' or ')'))
+                    sb.Append(c);
+                else if (c < 128 && c is '<' or '>' or ':' or '"' or '/' or '\\' or '|' or '?' or '*')
+                    sb.Append('_');
+                else if (c >= 128)
+                    sb.Append('_');
+                else if (char.IsControl(c))
+                    sb.Append('_');
+                else
+                    sb.Append('_');
+            }
+
+            string result = Regex.Replace(sb.ToString(), @"_+", "_").Trim(' ', '.', '_');
+            return string.IsNullOrEmpty(result) ? "_" : result.SanitizeFileName();
         }
     }
 }

--- a/PS4PKGTool/Utilities/PS4PKGToolHelper/Helper.cs
+++ b/PS4PKGTool/Utilities/PS4PKGToolHelper/Helper.cs
@@ -25,6 +25,7 @@ using PS4PKGTool.Util;
 using System.Reflection;
 using System.Net.Http;
 using DarkUI.Controls;
+using PS4PKGTool;
 
 namespace PS4PKGTool.Utilities.PS4PKGToolHelper
 {
@@ -56,14 +57,81 @@ namespace PS4PKGTool.Utilities.PS4PKGToolHelper
         public static string AppDataDirectory = AppContext.BaseDirectory + @"AppData\";
 
         /// <summary>
+        /// Returns a writable root path that is fully ASCII. orbis-pub-cmd rejects any
+        /// non-ASCII character in in_path/out_path (fullwidth ＆, Japanese titles, and
+        /// even %TEMP% under a non-ASCII Windows username all fail with
+        /// "in_path or out_path is invalid").
+        /// When <paramref name="preferredVolumePath"/> is set, same-volume roots are
+        /// preferred so large PKG File.Move stays on one drive.
+        /// </summary>
+        public static string GetAsciiTempRoot(string preferredVolumePath = null)
+        {
+            string preferredRoot = null;
+            if (!string.IsNullOrEmpty(preferredVolumePath))
+            {
+                try { preferredRoot = Path.GetPathRoot(Path.GetFullPath(preferredVolumePath)); }
+                catch { preferredRoot = Path.GetPathRoot(preferredVolumePath); }
+            }
+
+            var candidates = new List<string>();
+            void Add(string path)
+            {
+                if (string.IsNullOrWhiteSpace(path)) return;
+                try { path = Path.GetFullPath(path); } catch { return; }
+                if (!path.IsAsciiPath()) return;
+                if (!candidates.Contains(path, StringComparer.OrdinalIgnoreCase))
+                    candidates.Add(path);
+            }
+
+            Add(Path.GetTempPath());
+            Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "PS4PKGTool", "tmp"));
+            string windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            if (!string.IsNullOrEmpty(windows))
+                Add(Path.Combine(windows, "Temp"));
+            string sysRoot = Path.GetPathRoot(Environment.SystemDirectory);
+            if (!string.IsNullOrEmpty(sysRoot))
+                Add(Path.Combine(sysRoot, "p4t_tmp"));
+            if (!string.IsNullOrEmpty(preferredRoot))
+                Add(Path.Combine(preferredRoot, "p4t_tmp"));
+
+            IEnumerable<string> ordered = candidates;
+            if (!string.IsNullOrEmpty(preferredRoot))
+            {
+                ordered = candidates
+                    .Where(c => c.StartsWith(preferredRoot, StringComparison.OrdinalIgnoreCase))
+                    .Concat(candidates.Where(c => !c.StartsWith(preferredRoot, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            foreach (string root in ordered)
+            {
+                try
+                {
+                    Directory.CreateDirectory(root);
+                    // Prove the directory is writable
+                    string probe = Path.Combine(root, "p4t_w_" + Guid.NewGuid().ToString("N").Substring(0, 6));
+                    Directory.CreateDirectory(probe);
+                    Directory.Delete(probe);
+                    return root;
+                }
+                catch { }
+            }
+
+            // Last resort — may still be non-ASCII on some machines; callers will surface orbis errors.
+            string fallback = Path.GetTempPath();
+            Directory.CreateDirectory(fallback);
+            return fallback;
+        }
+
+        /// <summary>
         /// Creates a short ASCII temp directory for orbis-pub-cmd working files.
-        /// The system temp root plus a short name keeps paths under MAX_PATH even for
-        /// games with deep internal structures (e.g. Ultrawings' StreamingAssets schemas).
+        /// Avoids Path.GetTempPath() when it contains non-ASCII characters (common with
+        /// non-English Windows usernames). Short names also keep deep PKG trees under MAX_PATH.
         /// The caller must delete the returned directory when done.
         /// </summary>
         public static string CreateOrbisTempDir(string tag)
         {
-            string dir = Path.Combine(Path.GetTempPath(), "p4t_" + tag + "_" + Guid.NewGuid().ToString("N").Substring(0, 6));
+            string root = GetAsciiTempRoot();
+            string dir = Path.Combine(root, "p4t_" + tag + "_" + Guid.NewGuid().ToString("N").Substring(0, 6));
             Directory.CreateDirectory(dir);
             return dir;
         }

--- a/PS4PKGTool/Utilities/PS4PKGToolHelper/OrbisTempSafety.cs
+++ b/PS4PKGTool/Utilities/PS4PKGToolHelper/OrbisTempSafety.cs
@@ -90,9 +90,12 @@ namespace PS4PKGTool.Utilities.PS4PKGToolHelper
                 if (!seen.Add(orphan)) continue;
                 try
                 {
-                    if (TryRestoreFromSidecar(orphan))
+                    // If a sidecar exists, only attempt path restore — never fall through to
+                    // Title-ID rename (that would "recover" a conflict temp into a new name).
+                    if (File.Exists(SidecarPath(orphan)))
                     {
-                        recovered++;
+                        if (TryRestoreFromSidecar(orphan))
+                            recovered++;
                         continue;
                     }
                     if (TryRecoverWithoutSidecar(orphan))

--- a/PS4PKGTool/Utilities/PS4PKGToolHelper/OrbisTempSafety.cs
+++ b/PS4PKGTool/Utilities/PS4PKGToolHelper/OrbisTempSafety.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PS4PKGTool;
+using PS4PKGTool.Util;
+
+namespace PS4PKGTool.Utilities.PS4PKGToolHelper
+{
+    /// <summary>
+    /// Reliability helpers for orbis-pub-cmd temp renames: restore sidecars, orphan recovery,
+    /// stale temp cleanup, and disk-space checks before large extracts.
+    /// </summary>
+    public static class OrbisTempSafety
+    {
+        public const string TempPkgPrefix = "ps4pkgtool_orbis_";
+        public const string RestoreSidecarSuffix = ".restore";
+
+        /// <summary>Move a file, falling back to copy+delete when volumes differ.</summary>
+        public static void SafeMoveFile(string src, string dst)
+        {
+            try
+            {
+                if (File.Exists(dst)) File.Delete(dst);
+                File.Move(src, dst);
+            }
+            catch (IOException)
+            {
+                File.Copy(src, dst, overwrite: true);
+                try { File.Delete(src); } catch { /* leave source if delete fails after copy */ }
+            }
+        }
+
+        public static string SidecarPath(string tempPkgPath) => tempPkgPath + RestoreSidecarSuffix;
+
+        /// <summary>Rename PKG for orbis and record original path for crash recovery.</summary>
+        public static void BeginOrbisPkgRename(string originalPath, string tempPkgPath)
+        {
+            SafeMoveFile(originalPath, tempPkgPath);
+            try
+            {
+                File.WriteAllText(SidecarPath(tempPkgPath), originalPath ?? "");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Could not write PKG restore sidecar: " + ex.Message);
+            }
+        }
+
+        /// <summary>Move PKG back to original path and remove sidecar.</summary>
+        public static void EndOrbisPkgRestore(string tempPkgPath, string originalPath)
+        {
+            try
+            {
+                if (File.Exists(tempPkgPath))
+                {
+                    if (File.Exists(originalPath))
+                        Logger.LogError("Failed to restore PKG filename because the original path already exists. Recover the PKG from: " + tempPkgPath);
+                    else
+                        SafeMoveFile(tempPkgPath, originalPath);
+                }
+            }
+            finally
+            {
+                TryDeleteSidecar(tempPkgPath);
+            }
+        }
+
+        public static void TryDeleteSidecar(string tempPkgPath)
+        {
+            try
+            {
+                string side = SidecarPath(tempPkgPath);
+                if (File.Exists(side)) File.Delete(side);
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Find leftover ps4pkgtool_orbis_*.pkg files and restore them using sidecars,
+        /// or rename via Title ID when no sidecar exists.
+        /// </summary>
+        public static int RecoverOrphanedPkgs(IEnumerable<string> searchRoots)
+        {
+            int recovered = 0;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string orphan in EnumerateTempPkgs(searchRoots))
+            {
+                if (!seen.Add(orphan)) continue;
+                try
+                {
+                    if (TryRestoreFromSidecar(orphan))
+                    {
+                        recovered++;
+                        continue;
+                    }
+                    if (TryRecoverWithoutSidecar(orphan))
+                        recovered++;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning("Orphan PKG recovery failed for " + orphan + ": " + ex.Message);
+                }
+            }
+            return recovered;
+        }
+
+        /// <summary>Delete stale p4t_* temp directories older than <paramref name="maxAge"/>.</summary>
+        public static int CleanupStaleTempDirectories(TimeSpan maxAge)
+        {
+            int removed = 0;
+            DateTime cutoff = DateTime.UtcNow - maxAge;
+            var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            try { roots.Add(Path.GetFullPath(Path.GetTempPath())); } catch { }
+            try { roots.Add(Path.GetFullPath(Helper.GetAsciiTempRoot())); } catch { }
+            try
+            {
+                string common = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                    "PS4PKGTool", "tmp");
+                roots.Add(Path.GetFullPath(common));
+            }
+            catch { }
+            try
+            {
+                string sysRoot = Path.GetPathRoot(Environment.SystemDirectory);
+                if (!string.IsNullOrEmpty(sysRoot))
+                    roots.Add(Path.GetFullPath(Path.Combine(sysRoot, "p4t_tmp")));
+            }
+            catch { }
+
+            foreach (string root in roots)
+            {
+                if (!Directory.Exists(root)) continue;
+                IEnumerable<string> dirs;
+                try
+                {
+                    dirs = Directory.EnumerateDirectories(root, "p4t_*", SearchOption.TopDirectoryOnly);
+                }
+                catch { continue; }
+
+                foreach (string dir in dirs)
+                {
+                    try
+                    {
+                        var info = new DirectoryInfo(dir);
+                        // Keep folders touched within maxAge (active or recent jobs)
+                        if (info.LastWriteTimeUtc > cutoff)
+                            continue;
+                        // Only remove if no live rename sidecars (active job)
+                        bool hasActiveSidecar = Directory.EnumerateFiles(dir, TempPkgPrefix + "*" + RestoreSidecarSuffix, SearchOption.TopDirectoryOnly).Any();
+                        if (hasActiveSidecar) continue;
+
+                        Directory.Delete(dir, recursive: true);
+                        removed++;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogWarning("Temp cleanup skipped " + dir + ": " + ex.Message);
+                    }
+                }
+            }
+            return removed;
+        }
+
+        /// <summary>
+        /// Ensure enough free space for a full extract. Uses a conservative multiple of PKG size
+        /// on the temp volume and the destination volume.
+        /// </summary>
+        public static bool HasEnoughDiskSpaceForExtract(string pkgPath, string destinationDirectory, out string message)
+        {
+            message = null;
+            try
+            {
+                long pkgSize = new FileInfo(pkgPath).Length;
+                if (pkgSize <= 0)
+                {
+                    message = "PKG file size is zero or unreadable.";
+                    return false;
+                }
+
+                // Extracted content is often larger than the PKG; temp + final can both hold a full tree.
+                long needPerVolume = checked(pkgSize * 2 + 64L * 1024 * 1024); // 2× + 64 MB headroom
+
+                string tempRoot = Helper.GetAsciiTempRoot(pkgPath);
+                string tempVol = Path.GetPathRoot(Path.GetFullPath(tempRoot));
+                string destVol = Path.GetPathRoot(Path.GetFullPath(destinationDirectory));
+
+                long freeTemp = GetAvailableBytes(tempVol);
+                long freeDest = GetAvailableBytes(destVol);
+
+                bool sameVolume = !string.IsNullOrEmpty(tempVol) && string.Equals(tempVol, destVol, StringComparison.OrdinalIgnoreCase);
+                if (sameVolume)
+                {
+                    long need = checked(pkgSize * 3 + 64L * 1024 * 1024);
+                    if (freeTemp < need)
+                    {
+                        message = $"Not enough free space on {tempVol}. Need about {Helper.RoundBytes(need)}, have {Helper.RoundBytes(freeTemp)}.";
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (freeTemp < needPerVolume)
+                    {
+                        message = $"Not enough free space on temp drive {tempVol}. Need about {Helper.RoundBytes(needPerVolume)}, have {Helper.RoundBytes(freeTemp)}.";
+                        return false;
+                    }
+                    if (freeDest < needPerVolume)
+                    {
+                        message = $"Not enough free space on destination drive {destVol}. Need about {Helper.RoundBytes(needPerVolume)}, have {Helper.RoundBytes(freeDest)}.";
+                        return false;
+                    }
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Don't block extract if free-space probe fails (e.g. odd network path)
+                Logger.LogWarning("Disk space check skipped: " + ex.Message);
+                message = null;
+                return true;
+            }
+        }
+
+        private static long GetAvailableBytes(string volumeRoot)
+        {
+            if (string.IsNullOrEmpty(volumeRoot)) return long.MaxValue;
+            var di = new DriveInfo(volumeRoot);
+            return di.IsReady ? di.AvailableFreeSpace : long.MaxValue;
+        }
+
+        private static IEnumerable<string> EnumerateTempPkgs(IEnumerable<string> searchRoots)
+        {
+            var list = new List<string>();
+            foreach (string root in searchRoots.Where(r => !string.IsNullOrWhiteSpace(r)))
+            {
+                string full;
+                try { full = Path.GetFullPath(root); } catch { continue; }
+                if (!Directory.Exists(full)) continue;
+
+                CollectInDirectory(full, list);
+                try
+                {
+                    foreach (string sub in Directory.EnumerateDirectories(full, "p4t_*", SearchOption.TopDirectoryOnly))
+                        CollectInDirectory(sub, list);
+                }
+                catch { }
+            }
+            return list;
+        }
+
+        private static void CollectInDirectory(string dir, List<string> list)
+        {
+            try
+            {
+                list.AddRange(Directory.EnumerateFiles(dir, TempPkgPrefix + "*.pkg", SearchOption.TopDirectoryOnly));
+            }
+            catch { }
+        }
+
+        private static bool TryRestoreFromSidecar(string tempPkgPath)
+        {
+            string side = SidecarPath(tempPkgPath);
+            if (!File.Exists(side)) return false;
+
+            string original;
+            try { original = File.ReadAllText(side).Trim(); }
+            catch { return false; }
+            if (string.IsNullOrEmpty(original)) return false;
+
+            string destDir = Path.GetDirectoryName(original);
+            if (string.IsNullOrEmpty(destDir) || !Directory.Exists(destDir))
+            {
+                Logger.LogWarning("Orphan PKG sidecar points to missing directory: " + original);
+                return false;
+            }
+
+            if (File.Exists(original))
+            {
+                Logger.LogWarning("Orphan PKG original already exists, leaving temp file: " + tempPkgPath);
+                return false;
+            }
+
+            SafeMoveFile(tempPkgPath, original);
+            TryDeleteSidecar(tempPkgPath);
+            Logger.LogInformation("Restored orphaned PKG to original path: " + original);
+            return true;
+        }
+
+        private static bool TryRecoverWithoutSidecar(string tempPkgPath)
+        {
+            // No sidecar (older build / crash before write). Rename in-place using package metadata.
+            try
+            {
+                var pkg = PS4_Tools.PKG.SceneRelated.Read_PKG(tempPkgPath);
+                string titleId = pkg.Param?.TITLEID;
+                if (string.IsNullOrWhiteSpace(titleId))
+                    titleId = "UNKNOWN";
+                string title = (pkg.PS4_Title ?? "recovered").SanitizeFileName();
+                if (title.Length > 80) title = title.Substring(0, 80);
+
+                string dir = Path.GetDirectoryName(tempPkgPath) ?? ".";
+                string dest = Path.Combine(dir, $"{titleId} - {title}.pkg");
+                int n = 1;
+                while (File.Exists(dest))
+                {
+                    dest = Path.Combine(dir, $"{titleId} - {title} ({n}).pkg");
+                    n++;
+                }
+
+                SafeMoveFile(tempPkgPath, dest);
+                TryDeleteSidecar(tempPkgPath);
+                Logger.LogInformation("Recovered orphaned PKG without sidecar as: " + dest);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Could not rename orphan PKG " + tempPkgPath + ": " + ex.Message);
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **#67 / #76**: orbis-pub-cmd fails on non-ASCII paths and could hang extract UI — use ASCII temp paths, no hard 10-min kill, show progress
- **#63**: SYSTEM_VER 10.50 was shown wrong (e.g. 1.05) — fix bit decode
- **#60**: recursive scan checkbox was ignored when off
- **#74 / #65**: nullref / crashes when sorting + filtering the grid

Fixes #67
Fixes #76
Fixes #63
Fixes #60
Fixes #74
Fixes #65